### PR TITLE
Fix ukiyo-e.org search: switch to multipart POST flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Xcode user-specific state
+xcuserdata/
+*.xcuserstate
+
+# Build output
+build/
+DerivedData/

--- a/ReverseImageSearch Extension/ReverseImageSearch_Extension.entitlements
+++ b/ReverseImageSearch Extension/ReverseImageSearch_Extension.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>XLREUF5H62.groups.reverseimagesearch</string>

--- a/ReverseImageSearch Extension/SafariExtensionHandler.m
+++ b/ReverseImageSearch Extension/SafariExtensionHandler.m
@@ -63,29 +63,97 @@
                                     inPage:(SFSafariPage *)page userInfo:(NSDictionary<NSString *, id> *)userInfo
 {
     NSString *image_uri = [userInfo valueForKey:@"uri"];
+    if (!image_uri)
+        return;
+
+    // ukiyo-e.org no longer accepts a GET search URL.  Image-URL search is now a
+    // multipart POST that returns a JSON results path, which we then open in a tab.
+    if ([command isEqualToString:@"ukiyo-e"])
+    {
+        [self searchUkiyoEWithImageURI:image_uri inPage:page];
+        return;
+    }
+
     NSString *search_uri = [self getSearchEngineString:command];
     // it turns out using URLQueryAllowedCharacterSet doesn't actually percent-encode for some reason.  Go figure.
-    image_uri = [image_uri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet alphanumericCharacterSet]];
+    NSString *encoded_uri = [image_uri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet alphanumericCharacterSet]];
     if (search_uri)
     {
-        search_uri = [NSString stringWithFormat:search_uri, image_uri];
+        search_uri = [NSString stringWithFormat:search_uri, encoded_uri];
+        [self openURL:[NSURL URLWithString:search_uri] inPage:page];
+    }
+}
+
+// ukiyo-e.org image search: POST the raw image URL as multipart/form-data, then
+// open the results page returned in the JSON response.  This runs in native code
+// via NSURLSession, so it is not subject to browser CORS restrictions.
+- (void)searchUkiyoEWithImageURI:(NSString *)image_uri inPage:(SFSafariPage *)page
+{
+    NSString *endpoint = [self getSearchEngineString:@"ukiyo-e"];
+    NSURL *url = endpoint ? [NSURL URLWithString:endpoint] : nil;
+    if (!url)
+        return;
+
+    NSString *boundary = @"----ReverseImageSearchBoundary";
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    request.HTTPMethod = @"POST";
+    [request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary]
+   forHTTPHeaderField:@"Content-Type"];
+
+    NSMutableData *body = [NSMutableData data];
+    [body appendData:[[NSString stringWithFormat:@"--%@\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+    [body appendData:[@"Content-Disposition: form-data; name=\"url\"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    [body appendData:[image_uri dataUsingEncoding:NSUTF8StringEncoding]];
+    [body appendData:[[NSString stringWithFormat:@"\r\n--%@--\r\n", boundary] dataUsingEncoding:NSUTF8StringEncoding]];
+    request.HTTPBody = body;
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request
+                                                                completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error || !data)
+        {
+            NSLog(@"ReverseImageSearch: ukiyo-e POST failed: %@", error);
+            return;
+        }
+        NSError *json_error = nil;
+        id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&json_error];
+        if (![json isKindOfClass:[NSDictionary class]])
+        {
+            NSLog(@"ReverseImageSearch: ukiyo-e response was not JSON: %@", json_error);
+            return;
+        }
+        NSString *status = [json objectForKey:@"status"];
+        NSString *results = [json objectForKey:@"results"];
+        if (![status isEqualToString:@"SUCCESS"] || results.length == 0)
+        {
+            NSLog(@"ReverseImageSearch: ukiyo-e search was unsuccessful: %@", json);
+            return;
+        }
+        NSURL *results_url = [NSURL URLWithString:results relativeToURL:url];
+        if (!results_url)
+        {
+            NSLog(@"ReverseImageSearch: ukiyo-e returned an invalid results path: %@", results);
+            return;
+        }
+        [self openURL:results_url inPage:page];
+    }];
+    [task resume];
+}
+
+- (void)openURL:(NSURL *)url inPage:(SFSafariPage *)page
+{
+    if (!url)
+        return;
+    dispatch_async(dispatch_get_main_queue(), ^{
         [page getContainingTabWithCompletionHandler:^(SFSafariTab * _Nonnull tab) {
             [tab getContainingWindowWithCompletionHandler:^(SFSafariWindow * _Nullable window) {
                 NSUserDefaults *defaults = [self userDefaults:[self createAppDefaults]];
                 BOOL result_in_background = [defaults boolForKey:@"prefResultInBackground"];
-                NSLog(@"result in background:  %d", result_in_background);
-                [window openTabWithURL:[NSURL URLWithString:search_uri] makeActiveIfPossible:!result_in_background completionHandler:^(SFSafariTab * _Nullable tab) {
+                [window openTabWithURL:url makeActiveIfPossible:!result_in_background completionHandler:^(SFSafariTab * _Nullable tab) {
                     // do nothing
                 }];
             }];
         }];
-//        [SFSafariApplication getActiveWindowWithCompletionHandler:^(SFSafariWindow * _Nullable activeWindow) {
-//            [activeWindow openTabWithURL:[NSURL URLWithString:search_uri] makeActiveIfPossible:YES completionHandler:^(SFSafariTab *tab) {
-//                NSLog(@"Page opened");
-//            }];
-//        }];
-    }
-
+    });
 }
 
 - (SFSafariExtensionViewController *)popoverViewController {

--- a/ReverseImageSearch Extension/SafariExtensionHandler.m
+++ b/ReverseImageSearch Extension/SafariExtensionHandler.m
@@ -121,17 +121,33 @@
             NSLog(@"ReverseImageSearch: ukiyo-e response was not JSON: %@", json_error);
             return;
         }
-        NSString *status = [json objectForKey:@"status"];
-        NSString *results = [json objectForKey:@"results"];
-        if (![status isEqualToString:@"SUCCESS"] || results.length == 0)
+        // The response is remote and untrusted: validate the JSON shape before
+        // using it, so an unexpected type (e.g. a number or object) cannot crash us.
+        id status = [json objectForKey:@"status"];
+        id results = [json objectForKey:@"results"];
+        if (![status isKindOfClass:[NSString class]] ||
+            ![results isKindOfClass:[NSString class]] ||
+            ![(NSString *)status isEqualToString:@"SUCCESS"] ||
+            [(NSString *)results length] == 0)
         {
             NSLog(@"ReverseImageSearch: ukiyo-e search was unsuccessful: %@", json);
             return;
         }
-        NSURL *results_url = [NSURL URLWithString:results relativeToURL:url];
+        NSURL *results_url = [NSURL URLWithString:(NSString *)results relativeToURL:url];
         if (!results_url)
         {
             NSLog(@"ReverseImageSearch: ukiyo-e returned an invalid results path: %@", results);
+            return;
+        }
+        // URLWithString:relativeToURL: ignores the base when results is absolute,
+        // so an off-site value (e.g. https://evil.com) would otherwise be opened.
+        // Restrict results to the configured endpoint's host over https.  Deriving
+        // the host from the (trusted, local) endpoint avoids drift if the plist
+        // changes, and fails safe: a nil host rejects every candidate.
+        if (![results_url.scheme isEqualToString:@"https"] ||
+            ![results_url.host isEqualToString:url.host])
+        {
+            NSLog(@"ReverseImageSearch: ukiyo-e returned an off-site results URL: %@", results_url);
             return;
         }
         [self openURL:results_url inPage:page];

--- a/Shared/search_engines.plist
+++ b/Shared/search_engines.plist
@@ -11,7 +11,7 @@
 	<key>tineye</key>
 	<string>https://tineye.com/search/?url=%@</string>
 	<key>ukiyo-e</key>
-	<string>https://ukiyo-e.org/upload/?url=%@</string>
+	<string>https://ukiyo-e.org/upload</string>
 	<key>ascii2d</key>
 	<string>https://ascii2d.net/search/url/%@</string>
 	<key>karmadecay</key>


### PR DESCRIPTION
## Summary

ukiyo-e.org was rebuilt and its old image-search endpoint changed, so the **Search on ukiyo-e.org** context-menu item is currently broken. The previous GET URL `https://ukiyo-e.org/upload?url=<image>` now 404s.

Image-URL search now works as a `multipart/form-data` **POST** to `/upload` with a single field `url` set to the raw image URL. The response is JSON:

```json
{ "status": "SUCCESS", "results": "/upload/c3f02d98-c460-49f4-9cb1-1575ba06bf92" }
```

`results` is a path; the user-facing results page is `https://ukiyo-e.org` + that path. So the flow changes from "build a GET URL and open it" to "POST the image URL, read the results path, then open it".

## Changes

- **`SafariExtensionHandler.m`** — ukiyo-e now routes through a new `searchUkiyoEWithImageURI:inPage:` that POSTs via `NSURLSession`, parses the JSON, and on `status == "SUCCESS"` opens `https://ukiyo-e.org<results>` in a new tab. All other search engines are unchanged. Tab-opening is factored into a shared `openURL:inPage:` helper, which keeps the existing "open results in background" preference working for every engine.

- **`ReverseImageSearch_Extension.entitlements`** — add `com.apple.security.network.client`, required for the sandboxed app extension to make the outbound request. The POST runs in native code, so there are no browser CORS concerns.

- **`search_engines.plist`** — point the `ukiyo-e` entry at the POST endpoint (`https://ukiyo-e.org/upload`).

- **`.gitignore`** — add one for Xcode user state (`xcuserdata/`, `*.xcuserstate`) and build output.

## Error handling

On a network error, a non-JSON response, or any `status` other than `SUCCESS`, it logs and does **not** open a tab — no broken result page.

## Testing

- Builds clean with `xcodebuild` (extension target).
- Manual: right-click an image → **Search on ukiyo-e.org** opens the rendered similar-image results page.
